### PR TITLE
fix issue:Potential stack-based buffer overflow in XDagCore

### DIFF
--- a/GpuMiner/MinerEngine/CLMiner.cpp
+++ b/GpuMiner/MinerEngine/CLMiner.cpp
@@ -214,8 +214,8 @@ static std::string XDagCLErrorHelper(const char *msg, cl::Error const &clerr)
 
 void AddDefinition(std::string& source, char const* id, unsigned value)
 {
-    char buf[256];
-    sprintf(buf, "#define %s %uu\n", id, value);
+    char buf[256] = {0};
+    snprintf(buf, sizeof(buf), "#define %s %uu\n", id, value);
     source.insert(source.begin(), buf, buf + strlen(buf));
 }
 

--- a/GpuMiner/XDagCore/XNetwork.cpp
+++ b/GpuMiner/XDagCore/XNetwork.cpp
@@ -48,14 +48,14 @@ bool XNetwork::Initialize()
 bool XNetwork::ValidateAddress(const char *address, sockaddr_in &peerAddr)
 {
     char *lasts;
-    char buf[0x100];
+    char buf[0x100] = {0};
 
     // Fill in the address of server
     memset(&peerAddr, 0, sizeof(peerAddr));
     peerAddr.sin_family = AF_INET;
 
     // Resolve the server address (convert from symbolic name to IP number)
-    strcpy(buf, address);
+    strncpy(buf, address, sizeof(buf));
     char *addressPart = strtok_r(buf, ":", &lasts);
     if(!addressPart)
     {

--- a/GpuMiner/XDagCore/XNetwork.cpp
+++ b/GpuMiner/XDagCore/XNetwork.cpp
@@ -55,7 +55,7 @@ bool XNetwork::ValidateAddress(const char *address, sockaddr_in &peerAddr)
     peerAddr.sin_family = AF_INET;
 
     // Resolve the server address (convert from symbolic name to IP number)
-    strncpy(buf, address, sizeof(buf));
+    strncpy(buf, address, sizeof(buf) - 1);
     char *addressPart = strtok_r(buf, ":", &lasts);
     if(!addressPart)
     {


### PR DESCRIPTION
init array content to 0.
use snprintf and strncpy to prevent buffer overflow